### PR TITLE
Reset File Explorer model on build/session events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.0.1
+
+### Fixed
+- File Explorer now refreshes properly after clearing a build or starting a new session.
+
 ## v2.0.0
 
 ### What's New in v2.0
@@ -42,8 +47,6 @@ All your builds save to `session.json` automatically. The app keeps 5 backup cop
 ### Important Changes
 
 **Settings**: "Copy Template Archives" renamed to "Enable Template Detection" (clearer meaning)
-
----
 
 ## v1.2.1
 ### Changed

--- a/app.py
+++ b/app.py
@@ -249,6 +249,7 @@ class DIMPackageGUI(QWidget):
         
         content_dir = get_build_content_dir(first_build.folder)
         if hasattr(self, 'fileExplorer'):
+            self.fileExplorer.reset_model()
             self.fileExplorer.setRootPath(content_dir)
         
         self.saveSession()
@@ -1273,6 +1274,9 @@ class DIMPackageGUI(QWidget):
         os.makedirs(content_dir, exist_ok=True)
         
         log.info(f"Build folder successfully cleared: {build_path}")
+        
+        if hasattr(self, 'fileExplorer'):
+            self.fileExplorer.reset_model()
         
         if self.current_build:
             self.current_build.content_status = "empty"

--- a/widgets.py
+++ b/widgets.py
@@ -1285,6 +1285,26 @@ class FileExplorer(QWidget):
                 if self.model.canFetchMore(content_index):
                     self.model.fetchMore(content_index)
                 self.treeView.expand(content_index)
+    
+    def reset_model(self):
+        current_path = self.current_path
+        
+        old_model = self.model
+        self.model = QFileSystemModel()
+        self.model.setRootPath('')
+        self.treeView.setModel(self.model)
+        
+        if old_model:
+            old_model.deleteLater()
+        
+        if not os.path.exists(current_path):
+            return
+            
+        specificIndex = self.model.index(current_path)
+        self.treeView.setRootIndex(specificIndex)
+        
+        if specificIndex.isValid() and self.model.canFetchMore(specificIndex):
+            self.model.fetchMore(specificIndex)
 
 
 class BuildListWidget(QWidget):
@@ -1661,6 +1681,9 @@ class BuildListWidget(QWidget):
                 main_gui = self.parent()
                 if main_gui and hasattr(main_gui, 'saveSession'):
                     main_gui.saveSession()
+                
+                if main_gui and hasattr(main_gui, 'fileExplorer'):
+                    main_gui.fileExplorer.reset_model()
                 
                 self.refreshList()
                 show_info(self.parent(), "Content Cleaned", f"Content cleaned for Build {build.part:02d}")


### PR DESCRIPTION
Fix FileExplorer showing empty content after folder recreate operations by forcing `QFileSystemModel` reset.

## Problem
`QFileSystemModel` maintains watchers to deleted directory inodes, causing empty views when folders are recreated.

## Solution
Added `FileExplorer.reset_model()` method that recreates the model and releases stale filesystem watchers.

Called `reset_model()` after all destructive operations:
- `cleanCurrentBuildFolder()` (Clear button)
- `onNewSession()` (New Session menu)
- `onCleanContent()` (Clean Content context menu)

Existing methods like `setRootPath()` don't release inode watchers—full model replacement is required.