### PR TITLE
Honor Clean Support option in packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - File Explorer now refreshes properly after clearing a build or starting a new session.
+- Fixed "Clean Support Directory" checkbox being ignored during batch packaging operations ("Package All" and "Package Selected").
 
 ## v2.0.0
 

--- a/app.py
+++ b/app.py
@@ -1568,7 +1568,7 @@ class DIMPackageGUI(QWidget):
                 product_part=build.part,
                 product_tags=build_data.get('tags', 'DAZStudio4_5'),
                 image_path=build_data.get('image_path', ''),
-                clean_support=self.clean_support_checkbox.isChecked() if hasattr(self, 'clean_support_checkbox') else False,
+                clean_support=self.support_clean_input.isChecked(),
                 guid=build.guid,
                 destination_folder=destination_folder
             )


### PR DESCRIPTION
This pull request addresses an issue where the "Clean Support Directory" checkbox was being ignored during packaging operations. The logic for determining whether to clean the support directory has been corrected to use the appropriate checkbox state.

Bug fix for batch packaging:

* Updated the logic in the `_packageBuilds` method in `app.py` to use the correct checkbox (`support_clean_input`) for the "Clean Support Directory" option during batch packaging operations, ensuring user preference is respected.
* Added a changelog entry noting the fix for the "Clean Support Directory" checkbox being ignored during "Package All" and "Package Selected" operations.Fix bug where the "Clean Support Directory" checkbox was ignored during batch packaging (Package All / Package Selected). app.py now uses support_clean_input.isChecked() for the clean_support flag instead of referencing clean_support_checkbox, ensuring the setting is respected. Updated CHANGELOG to document the fix.